### PR TITLE
add matomo tracking

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -54,6 +54,11 @@ module.exports = {
       "script",
       {},
       fs.readFileSync(path.join(__dirname, "./fathom-snippet.js"), "utf8")
+    ],
+    [
+      "script",
+      {},
+      fs.readFileSync(path.join(__dirname, "./matomo-snippet.js"), "utf8")
     ]
   ],
   configureWebpack: (config, isServer) => {

--- a/docs/.vuepress/matomo-snippet.js
+++ b/docs/.vuepress/matomo-snippet.js
@@ -1,0 +1,11 @@
+var _paq = window._paq = window._paq || [];
+_paq.push(['disableCookies']);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://zaikio.matomo.cloud/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '4']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/zaikio.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+})();


### PR DESCRIPTION
In the future we want to move the tracking from fathom to matomo for all websites. Currently they can run in parallel until we get rid of fathom. Matomo is set to correspond all GDPR requirements without showing the cookie banner as well.