### PR TITLE
Fix paddings for methods

### DIFF
--- a/docs/.vuepress/styles/swagger-ui.styl
+++ b/docs/.vuepress/styles/swagger-ui.styl
@@ -464,6 +464,7 @@
   .opblock .opblock-summary-method {
     border-radius: 2px;
     color: #000;
+    padding: 3px 6px;
     text-shadow: none;
   }
 

--- a/docs/.vuepress/styles/swagger-ui.styl
+++ b/docs/.vuepress/styles/swagger-ui.styl
@@ -464,7 +464,7 @@
   .opblock .opblock-summary-method {
     border-radius: 2px;
     color: #000;
-    padding: 3px 6px;
+    padding: 3px 9px;
     text-shadow: none;
   }
 


### PR DESCRIPTION
As suggested by @maprinz here is a little fix for the paddings of the methods.

## Before
<img width="1539" alt="Screenshot 2022-04-27 at 12 54 56" src="https://user-images.githubusercontent.com/1543655/165526990-320c7c89-c33f-4931-85c6-10feff220ce6.png">

## After
<img width="1539" alt="Screenshot 2022-04-27 at 12 55 22" src="https://user-images.githubusercontent.com/1543655/165526970-3b6d1dd1-14a8-4de7-a7d3-c828ef090467.png">

Sorry for the redundant commit, my editor didn’t show the first one after the push was denied due to missing access rights (fixed now).