### PR TITLE
Fix Heroku 404

### DIFF
--- a/static.json
+++ b/static.json
@@ -5,5 +5,6 @@
     "/docs/shared/**": {
       "Access-Control-Allow-Origin": "*"
     }
-  }
+  },
+  "clean_urls": true
 }


### PR DESCRIPTION
There is an issue in the built version on Heroku that produces 404 errors when navigating. Here is how to reproduce it:

1. Open the docs: https://docs.zaikio.com/
2. Open any link in the sidebar in a new tab OR copy any sidebar link and paste it in a new window
3. nginx 404 shows up
4. (When manually appending `.html` to the URL, the page loads correctly)

https://user-images.githubusercontent.com/1543655/170263393-9b95f707-47aa-4b15-9af8-c68d7bd06ca5.mov

**Note:** I can only assume that this is caused by _Heroku Buildpack Static_. The `clean_url` setting is `false` per default, so this pull request enables it and hopefully resolves this issue. However, I cannot test it without setting up a Heroku app or making changes to the existing one (e.g. adding staging) – which I lack the access rights for. But the issue does not occur locally and furthermore, I tested the app on Netlify and it doesn’t have this issue. Both tests implicate to me that this is a Heroku-specific issue – most likely with the Buildpack.

Other potential ways to solve it (not tested or validated): Updating the nginx config of the Heroku app to redirect to `index.html` (not sure if the routing is set up to work this way) or disabling clean URLs in the sidebar.