### PR TITLE
Remove release date for dropping refresh tokens on client credentials

### DIFF
--- a/docs/changelog/2022-08-09_client-credentials-drop-refresh-token.md
+++ b/docs/changelog/2022-08-09_client-credentials-drop-refresh-token.md
@@ -26,5 +26,5 @@ description: >
 
   ### What's next?
 
-  - On **Monday August 8th, 2022 around 10:00 AM CEST** we will drop the `refresh_token` from the `client_credentials` responses.
+  - On **TBA (paused)** we will drop the `refresh_token` from the `client_credentials` responses.
 ---


### PR DESCRIPTION
In discussion with our partners the date is not realistic. We will catch up with them and update the date soon